### PR TITLE
treewide: Fix CFG check

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -4,3 +4,4 @@ TabWidth: 4
 UseTab: Never
 SortIncludes: false
 SortUsingDeclarations: false
+ColumnLimit: 100

--- a/Checksec.cc
+++ b/Checksec.cc
@@ -10,6 +10,10 @@
 #include "vendor/json.hpp"
 using json = nlohmann::json;
 
+#define REPORT_EXPLAIN(presence, description, explanation) \
+    { MitigationPresence::presence, description, explanation }
+#define REPORT(presence, description) REPORT_EXPLAIN(presence, description, std::nullopt)
+
 namespace checksec {
 
 void to_json(json& j, const MitigationPresence& p) {

--- a/Checksec.h
+++ b/Checksec.h
@@ -27,10 +27,6 @@ using json = nlohmann::json;
 
 namespace checksec {
 
-#define REPORT_EXPLAIN(presence, description, explanation) \
-    { MitigationPresence::presence, description, explanation }
-#define REPORT(presence, description) REPORT_EXPLAIN(presence, description, std::nullopt)
-
 constexpr const char kDynamicBaseDescription[] =
     "Binaries with dynamic base support can be "
     "dynamically rebased, enabling ASLR.";

--- a/Checksec.h
+++ b/Checksec.h
@@ -29,8 +29,7 @@ namespace checksec {
 
 #define REPORT_EXPLAIN(presence, description, explanation) \
     { MitigationPresence::presence, description, explanation }
-#define REPORT(presence, description) \
-    REPORT_EXPLAIN(presence, description, std::nullopt)
+#define REPORT(presence, description) REPORT_EXPLAIN(presence, description, std::nullopt)
 
 constexpr const char kDynamicBaseDescription[] =
     "Binaries with dynamic base support can be "

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+CLANG_FORMAT := clang-format
 ALL_SRCS := $(wildcard *.cc) $(wildcard *.h)
 
 .PHONY: all


### PR DESCRIPTION
Also fixes the `make clang-format` target.

Fixes #52.