### PR TITLE
checksec: Be a little more defensive about load config loading

### DIFF
--- a/checksec.cpp
+++ b/checksec.cpp
@@ -85,14 +85,14 @@ Checksec::Checksec(std::string filepath) : filepath_(filepath), loadedImage_(fil
                       << "\n";
             return;
         }
-        peparse::image_load_config_64 loadConfig;
+        peparse::image_load_config_64 loadConfig{};
         if (loadConfigData.size() > sizeof(loadConfig)) {
             std::cerr << "Warn: large load config, probably contains undocumented "
                          "fields"
                       << "\n";
         }
         memcpy(&loadConfig, loadConfigData.data(), sizeof(loadConfig));
-        loadConfigSize_ = loadConfig.Size;
+        loadConfigSize_ = loadConfigData.size();
         loadConfigGuardFlags_ = loadConfig.GuardFlags;
         loadConfigSecurityCookie_ = loadConfig.SecurityCookie;
         loadConfigSEHandlerTable_ = loadConfig.SEHandlerTable;
@@ -120,14 +120,14 @@ Checksec::Checksec(std::string filepath) : filepath_(filepath), loadedImage_(fil
                       << "\n";
             return;
         }
-        peparse::image_load_config_32 loadConfig;
+        peparse::image_load_config_32 loadConfig{};
         if (loadConfigData.size() > sizeof(loadConfig)) {
             std::cerr << "Warn: large load config, probably contains undocumented "
                          "fields"
                       << "\n";
         }
         memcpy(&loadConfig, loadConfigData.data(), sizeof(loadConfig));
-        loadConfigSize_ = loadConfig.Size;
+        loadConfigSize_ = loadConfigData.size();
         loadConfigGuardFlags_ = loadConfig.GuardFlags;
         loadConfigSecurityCookie_ = loadConfig.SecurityCookie;
         loadConfigSEHandlerTable_ = loadConfig.SEHandlerTable;


### PR DESCRIPTION
Insure that our selected load config structure is zero-initialized,
and use its buffer size rather than its internal (self-reported) size.

Fixes #84.