### PR TITLE
checksec: Use 32 bit load config offsets for x86.

### DIFF
--- a/checksec.cpp
+++ b/checksec.cpp
@@ -196,9 +196,11 @@ const MitigationReport Checksec::isAuthenticode() const {
 }
 
 const MitigationReport Checksec::isRFG() const {
-    // NOTE(ww): a load config under 148 bytes implies the absence of the
-    // GuardFlags field.
-    if (loadConfigSize_ < 148) {
+    // NOTE(ww): a load config under 92/148 bytes implies the absence of the
+    // GuardFlags field. See:
+    // https://docs.microsoft.com/en-us/windows/win32/debug/pe-format#load-configuration-layout
+    if ((targetMachine_ == peparse::IMAGE_FILE_MACHINE_I386 && loadConfigSize_ < 92) ||
+        loadConfigSize_ < 148) {
         return REPORT_EXPLAIN(NotPresent, kRFGDescription,
                               "Image load config is too short to contain RFG "
                               "configuration fields.");
@@ -219,9 +221,10 @@ const MitigationReport Checksec::isSafeSEH() const {
                               "The SafeSEH mitigation only applies to x86_32 binaries.");
     }
 
-    // NOTE(ww): a load config under 112 bytes implies the absence of the
+    // NOTE(ww): a load config under 72/112 bytes implies the absence of the
     // SafeSEH fields.
-    if (loadConfigSize_ < 112) {
+    if ((targetMachine_ == peparse::IMAGE_FILE_MACHINE_I386 && loadConfigSize_ < 72) ||
+        loadConfigSize_ < 112) {
         return REPORT_EXPLAIN(NotPresent, kSafeSEHDescription,
                               "Image load config is too short to contain a SE handler table.");
     }
@@ -234,9 +237,10 @@ const MitigationReport Checksec::isSafeSEH() const {
 }
 
 const MitigationReport Checksec::isGS() const {
-    // NOTE(ww): a load config under 96 bytes implies the absence of the
+    // NOTE(ww): a load config under 64/96 bytes implies the absence of the
     // SecurityCookie field.
-    if (loadConfigSize_ < 96) {
+    if ((targetMachine_ == peparse::IMAGE_FILE_MACHINE_I386 && loadConfigSize_ < 64) ||
+        loadConfigSize_ < 96) {
         return REPORT_EXPLAIN(NotPresent, kGSDescription,
                               "Image load config is too short to contain a GS security cookie.");
     }


### PR DESCRIPTION
The fast out checks based on Load Configuration table offsets were
previously hardcoded for their 64 bit values, resulting in incorrect
results for 32 bit binaries.

We now use the 32 bit offsets for x86 binaries, while still using the 64
bit offsets for x64 and Itanium.

Fixes #1038.